### PR TITLE
Replaced the joint_state_publisher

### DIFF
--- a/warthog_gazebo/launch/warthog_sim.launch
+++ b/warthog_gazebo/launch/warthog_sim.launch
@@ -8,8 +8,11 @@
   <include file="$(find warthog_description)/launch/description.launch">
     <arg name="config" value="$(arg config)" />
   </include>
+
   <!-- joint_state_publisher is needed to pushish the suspension joints. -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <!-- node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" /-->
+  <node name="diff_publisher" pkg="warthog_gazebo" type="diff_publisher.py" />
+
   <include file="$(find warthog_control)/launch/control.launch" />
   <include file="$(find warthog_control)/launch/teleop.launch" />
 

--- a/warthog_gazebo/scripts/diff_publisher.py
+++ b/warthog_gazebo/scripts/diff_publisher.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import rospy
+from sensor_msgs.msg import JointState
+
+def publish_dummy_diffs():
+  jsm = JointState()
+  joint_names = ['left_diff_unit_jnt', 'right_diff_unit_jnt']
+  joint_values = [0.0, 0.0]
+  jsm.name = joint_names
+  jsm.position = joint_values
+
+  rospy.init_node('diff_joint_state_publisher', anonymous=True)
+  rate = rospy.Rate(10)
+
+  joint_states_pub = rospy.Publisher('/joint_states', JointState, queue_size=10)
+
+  while not rospy.is_shutdown():
+      jsm.header.stamp = rospy.Time.now()
+      joint_states_pub.publish(jsm)
+      rate.sleep()
+
+if __name__ == '__main__':
+  publish_dummy_diffs()


### PR DESCRIPTION
Replaced the joint_state_publisher with a basic python node to publish only the diff units at 0.  The joint_state_publisher was constantly publishing 0 for all joints, which was confusing things