### PR TITLE
Use the joy_enabled arg when spawning the simulated Warthog

### DIFF
--- a/warthog_gazebo/launch/spawn_warthog.launch
+++ b/warthog_gazebo/launch/spawn_warthog.launch
@@ -15,7 +15,9 @@
   <!-- joint_state_publisher is needed to pushish the suspension joints. -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
   <include file="$(find warthog_control)/launch/control.launch" />
-  <include file="$(find warthog_control)/launch/teleop.launch" />
+  <include file="$(find warthog_control)/launch/teleop.launch">
+    <arg name="enable_joy" value="1" />
+  </include>
 
   <!-- Spawn Warthog -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model"


### PR DESCRIPTION
Previously to enable game-controller teleop the WARTHOG_JOY_TELEOP envar needed to be set.  You're unlikely to have a Futaba controller connected to Gazebo, so for ease-of-use always enable game controller input in the simulation.